### PR TITLE
feat (Legacy): Implement animated image support for GIF/WebP

### DIFF
--- a/app/src/main/kotlin/org/dokiteam/doki/core/image/CoilImageView.kt
+++ b/app/src/main/kotlin/org/dokiteam/doki/core/image/CoilImageView.kt
@@ -34,6 +34,8 @@ import org.dokiteam.doki.core.util.ext.decodeRegion
 import org.dokiteam.doki.core.util.ext.getAnimationDuration
 import org.dokiteam.doki.core.util.ext.isAnimationsEnabled
 import org.dokiteam.doki.core.util.ext.isNetworkError
+import org.dokiteam.doki.core.util.ext.mangaSourceExtra
+import org.dokiteam.doki.reader.ui.pager.ReaderPage
 import java.util.LinkedList
 import javax.inject.Inject
 
@@ -126,6 +128,13 @@ open class CoilImageView @JvmOverloads constructor(
 	fun setImageAsync(url: String?) = enqueueRequest(
 		newRequestBuilder()
 			.data(url)
+			.build(),
+	)
+
+	open fun setImageAsync(page: ReaderPage) = enqueueRequest(
+		newRequestBuilder()
+			.data(page.toMangaPage())
+			.mangaSourceExtra(page.source)
 			.build(),
 	)
 

--- a/app/src/main/kotlin/org/dokiteam/doki/core/util/ext/String.kt
+++ b/app/src/main/kotlin/org/dokiteam/doki/core/util/ext/String.kt
@@ -72,6 +72,8 @@ fun <T> Collection<T>.joinToStringWithLimit(context: Context, limit: Int, transf
 
 fun String.isHttpUrl() = startsWith("https://", ignoreCase = true) || startsWith("http://", ignoreCase = true)
 
+fun String.isAnimatedImage() = endsWith(".gif", ignoreCase = true) || endsWith(".webp", ignoreCase = true)
+
 fun concatStrings(context: Context, a: String?, b: String?): String? = when {
 	a.isNullOrEmpty() && b.isNullOrEmpty() -> null
 	a.isNullOrEmpty() -> b?.nullIfEmpty()

--- a/app/src/main/kotlin/org/dokiteam/doki/image/ui/CoverImageView.kt
+++ b/app/src/main/kotlin/org/dokiteam/doki/image/ui/CoverImageView.kt
@@ -36,6 +36,7 @@ import org.dokiteam.doki.core.ui.image.TrimTransformation
 import org.dokiteam.doki.core.util.ext.bookmarkExtra
 import org.dokiteam.doki.core.util.ext.decodeRegion
 import org.dokiteam.doki.core.util.ext.getThemeColor
+import org.dokiteam.doki.core.util.ext.isAnimatedImage
 import org.dokiteam.doki.core.util.ext.isNetworkError
 import org.dokiteam.doki.core.util.ext.mangaExtra
 import org.dokiteam.doki.core.util.ext.mangaSourceExtra
@@ -109,22 +110,33 @@ class CoverImageView @JvmOverloads constructor(
 		}
 	}
 
-	fun setImageAsync(page: ReaderPage) = enqueueRequest(
-		newRequestBuilder()
+	private fun isAnimatedUrl(url: String?): Boolean = url?.isAnimatedImage() == true
+
+	private fun newRequestBuilder(applyTrim: Boolean) = super.newRequestBuilder().apply {
+		if (trimImage && applyTrim) {
+			transformations(listOf(TrimTransformation()))
+		}
+		if (hasAspectRatio) {
+			size(CoverSizeResolver(this@CoverImageView))
+		}
+	}
+
+	override fun setImageAsync(page: ReaderPage) = enqueueRequest(
+		newRequestBuilder(applyTrim = true)
 			.data(page.toMangaPage())
 			.mangaSourceExtra(page.source)
 			.build(),
 	)
 
 	fun setImageAsync(page: MangaPage) = enqueueRequest(
-		newRequestBuilder()
+		newRequestBuilder(applyTrim = true)
 			.data(page)
 			.mangaSourceExtra(page.source)
 			.build(),
 	)
 
 	fun setImageAsync(cover: Cover?) = enqueueRequest(
-		newRequestBuilder()
+		newRequestBuilder(applyTrim = !isAnimatedUrl(cover?.url))
 			.data(cover?.url)
 			.mangaSourceExtra(cover?.mangaSource)
 			.build(),
@@ -134,7 +146,7 @@ class CoverImageView @JvmOverloads constructor(
 		coverUrl: String?,
 		manga: Manga?,
 	) = enqueueRequest(
-		newRequestBuilder()
+		newRequestBuilder(applyTrim = !isAnimatedUrl(coverUrl))
 			.data(coverUrl)
 			.mangaExtra(manga)
 			.build(),
@@ -144,7 +156,7 @@ class CoverImageView @JvmOverloads constructor(
 		coverUrl: String?,
 		source: MangaSource,
 	) = enqueueRequest(
-		newRequestBuilder()
+		newRequestBuilder(applyTrim = !isAnimatedUrl(coverUrl))
 			.data(coverUrl)
 			.mangaSourceExtra(source)
 			.build(),
@@ -153,21 +165,15 @@ class CoverImageView @JvmOverloads constructor(
 	fun setImageAsync(
 		bookmark: Bookmark
 	) = enqueueRequest(
-		newRequestBuilder()
+		newRequestBuilder(applyTrim = true)
 			.data(bookmark.toMangaPage())
 			.decodeRegion(bookmark.scroll)
 			.bookmarkExtra(bookmark)
 			.build(),
 	)
 
-	override fun newRequestBuilder() = super.newRequestBuilder().apply {
-		if (trimImage) {
-			transformations(listOf(TrimTransformation()))
-		}
-		if (hasAspectRatio) {
-			size(CoverSizeResolver(this@CoverImageView))
-		}
-	}
+	@Deprecated("Use newRequestBuilder(applyTrim) instead", level = DeprecationLevel.HIDDEN)
+	override fun newRequestBuilder() = newRequestBuilder(applyTrim = true)
 
 	@RequiresApi(Build.VERSION_CODES.M)
 	private inner class ErrorForegroundListener : ImageRequest.Listener {

--- a/app/src/main/kotlin/org/dokiteam/doki/image/ui/ImageActivity.kt
+++ b/app/src/main/kotlin/org/dokiteam/doki/image/ui/ImageActivity.kt
@@ -17,13 +17,16 @@ import coil3.request.ErrorResult
 import coil3.request.ImageRequest
 import coil3.request.SuccessResult
 import coil3.request.lifecycle
+import coil3.request.target
 import coil3.target.GenericViewTarget
+import coil3.target.Target
 import com.davemorrissey.labs.subscaleview.ImageSource
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import org.dokiteam.doki.R
 import org.dokiteam.doki.core.exceptions.resolve.SnackbarErrorObserver
+import org.dokiteam.doki.core.image.CoilImageView
 import org.dokiteam.doki.core.image.CoilMemoryCacheKey
 import org.dokiteam.doki.core.model.MangaSource
 import org.dokiteam.doki.core.nav.AppRouter
@@ -37,6 +40,7 @@ import org.dokiteam.doki.core.util.ext.getDisplayIcon
 import org.dokiteam.doki.core.util.ext.getDisplayMessage
 import org.dokiteam.doki.core.util.ext.getParcelableExtraCompat
 import org.dokiteam.doki.core.util.ext.getThemeColor
+import org.dokiteam.doki.core.util.ext.isAnimatedImage
 import org.dokiteam.doki.core.util.ext.mangaSourceExtra
 import org.dokiteam.doki.core.util.ext.observe
 import org.dokiteam.doki.core.util.ext.observeEvent
@@ -122,15 +126,34 @@ class ImageActivity : BaseActivity<ActivityImageBinding>(),
 	}
 
 	private fun loadImage() {
-		ImageRequest.Builder(this)
-			.data(intent.data)
-			.memoryCacheKey(intent.getParcelableExtraCompat<CoilMemoryCacheKey>(AppRouter.KEY_PREVIEW)?.data)
-			.memoryCachePolicy(CachePolicy.READ_ONLY)
-			.lifecycle(this)
-			.listener(this)
-			.mangaSourceExtra(MangaSource(intent.getStringExtra(AppRouter.KEY_SOURCE)))
-			.target(SsivTarget(viewBinding.ssiv))
-			.enqueueWith(coil)
+		val url = intent.data?.toString()
+		val isAnimated = url?.isAnimatedImage() == true
+
+		if (isAnimated) {
+			viewBinding.ssiv.isVisible = false
+			viewBinding.animatedView.isVisible = true
+			ImageRequest.Builder(this)
+				.data(intent.data)
+				.memoryCacheKey(intent.getParcelableExtraCompat<CoilMemoryCacheKey>(AppRouter.KEY_PREVIEW)?.data)
+				.memoryCachePolicy(CachePolicy.READ_ONLY)
+				.lifecycle(this)
+				.listener(this)
+				.mangaSourceExtra(MangaSource(intent.getStringExtra(AppRouter.KEY_SOURCE)))
+				.target(viewBinding.animatedView)
+				.enqueueWith(coil)
+		} else {
+			viewBinding.ssiv.isVisible = true
+			viewBinding.animatedView.isVisible = false
+			ImageRequest.Builder(this)
+				.data(intent.data)
+				.memoryCacheKey(intent.getParcelableExtraCompat<CoilMemoryCacheKey>(AppRouter.KEY_PREVIEW)?.data)
+				.memoryCachePolicy(CachePolicy.READ_ONLY)
+				.lifecycle(this)
+				.listener(this)
+				.mangaSourceExtra(MangaSource(intent.getStringExtra(AppRouter.KEY_SOURCE)))
+				.target(SsivTarget(viewBinding.ssiv))
+				.enqueueWith(coil)
+		}
 	}
 
 	private fun onImageSaved(uri: Uri) {

--- a/app/src/main/kotlin/org/dokiteam/doki/reader/ui/pager/BasePageHolder.kt
+++ b/app/src/main/kotlin/org/dokiteam/doki/reader/ui/pager/BasePageHolder.kt
@@ -14,13 +14,16 @@ import androidx.viewbinding.ViewBinding
 import com.davemorrissey.labs.subscaleview.DefaultOnImageEventListener
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.dokiteam.doki.BuildConfig
 import org.dokiteam.doki.R
 import org.dokiteam.doki.core.exceptions.resolve.ExceptionResolver
+import org.dokiteam.doki.core.image.CoilImageView
 import org.dokiteam.doki.core.os.NetworkState
 import org.dokiteam.doki.core.ui.list.lifecycle.LifecycleAwareViewHolder
 import org.dokiteam.doki.core.util.ext.getDisplayMessage
+import org.dokiteam.doki.core.util.ext.isAnimatedImage
 import org.dokiteam.doki.core.util.ext.isLowRamDevice
 import org.dokiteam.doki.core.util.ext.isSerializable
 import org.dokiteam.doki.core.util.ext.observe
@@ -50,6 +53,10 @@ abstract class BasePageHolder<B : ViewBinding>(
 	)
 	protected val bindingInfo = LayoutPageInfoBinding.bind(binding.root)
 	protected abstract val ssiv: SubsamplingScaleImageView
+
+	protected val animatedView: CoilImageView? by lazy {
+		itemView.findViewById(R.id.animatedView)
+	}
 
 	protected val settings: ReaderSettings
 		get() = viewModel.settingsProducer.value
@@ -99,6 +106,9 @@ abstract class BasePageHolder<B : ViewBinding>(
 
 	fun bind(data: ReaderPage) {
 		boundData = data
+		ssiv.isVisible = true
+		animatedView?.isVisible = false
+		animatedView?.disposeImage()
 		viewModel.onBind(data.toMangaPage())
 		onBind(data)
 	}
@@ -139,6 +149,7 @@ abstract class BasePageHolder<B : ViewBinding>(
 	open fun onRecycled() {
 		viewModel.onRecycle()
 		ssiv.recycle()
+		animatedView?.disposeImage()
 	}
 
 	override fun onTrimMemory(level: Int) {
@@ -162,6 +173,7 @@ abstract class BasePageHolder<B : ViewBinding>(
 			bindingInfo.progressBar.isIndeterminate = true
 			bindingInfo.textViewStatus.setText(R.string.loading_)
 		}
+		val isAnimated = boundData?.url?.isAnimatedImage() == true
 		when (state) {
 			is PageState.Converting -> {
 				bindingInfo.textViewStatus.setText(R.string.processing_)
@@ -181,8 +193,13 @@ abstract class BasePageHolder<B : ViewBinding>(
 			}
 
 			is PageState.Loaded -> {
-				bindingInfo.textViewStatus.setText(R.string.preparing_)
-				ssiv.setImage(state.source)
+				if (isAnimated) {
+					showAnimated(boundData!!, state)
+					bindingInfo.layoutProgress.isGone = true
+				} else {
+					bindingInfo.textViewStatus.setText(R.string.preparing_)
+					ssiv.setImage(state.source)
+				}
 			}
 
 			is PageState.Loading -> {
@@ -192,6 +209,21 @@ abstract class BasePageHolder<B : ViewBinding>(
 			}
 
 			is PageState.Shown -> Unit
+		}
+	}
+
+	private fun showAnimated(page: ReaderPage, loadedState: PageState.Loaded) {
+		ssiv.isVisible = false
+		animatedView?.let {
+			it.isVisible = true
+			it.setImageAsync(page)
+		}
+		viewModel.state.update { currentState ->
+			if (currentState is PageState.Loaded) {
+				PageState.Shown(loadedState.source, loadedState.isConverted)
+			} else {
+				currentState
+			}
 		}
 	}
 

--- a/app/src/main/res/layout/activity_image.xml
+++ b/app/src/main/res/layout/activity_image.xml
@@ -13,6 +13,13 @@
 		app:restoreStrategy="deferred"
 		tools:background="@tools:sample/backgrounds/scenic" />
 
+	<org.dokiteam.doki.core.image.CoilImageView
+		android:id="@+id/animatedView"
+		android:layout_width="match_parent"
+		android:layout_height="match_parent"
+		android:scaleType="fitCenter"
+		android:visibility="gone" />
+
 	<ImageButton
 		android:id="@+id/button_back"
 		android:layout_width="48dp"

--- a/app/src/main/res/layout/item_page.xml
+++ b/app/src/main/res/layout/item_page.xml
@@ -15,6 +15,13 @@
 		app:doubleTapZoomStyle="center"
 		app:restoreStrategy="deferred" />
 
+	<org.dokiteam.doki.core.image.CoilImageView
+		android:id="@+id/animatedView"
+		android:layout_width="match_parent"
+		android:layout_height="match_parent"
+		android:scaleType="fitCenter"
+		android:visibility="gone" />
+
 	<TextView
 		android:id="@+id/textView_number"
 		android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_page_webtoon.xml
+++ b/app/src/main/res/layout/item_page_webtoon.xml
@@ -16,6 +16,14 @@
 		app:quickScaleEnabled="false"
 		app:zoomEnabled="false" />
 
+	<org.dokiteam.doki.core.image.CoilImageView
+		android:id="@+id/animatedView"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:adjustViewBounds="true"
+		android:scaleType="fitCenter"
+		android:visibility="gone" />
+
 	<include layout="@layout/layout_page_info" />
 
 </org.dokiteam.doki.reader.ui.pager.webtoon.WebtoonFrameLayout>


### PR DESCRIPTION
This commit introduces support for animated GIF and WebP images throughout the application.

Key changes:
- Added `CoilImageView` to handle animated images in the standard reader, webtoon reader, and full-screen cover view.
- Implemented an `isAnimatedImage()` extension function on `String` to detect animated image URLs.
- Updated `BasePageHolder` to dynamically switch between `SubsamplingScaleImageView` for static images and `CoilImageView` for animated ones.
- Modified `CoverImageView` to skip the `TrimTransformation` for animated images to prevent them from being frozen on the first frame.
- Refactored `ImageActivity` to use `CoilImageView` for displaying animated images.