### PR TITLE
fix: animated url logic

### DIFF
--- a/app/src/main/kotlin/org/dokiteam/doki/core/util/ext/String.kt
+++ b/app/src/main/kotlin/org/dokiteam/doki/core/util/ext/String.kt
@@ -72,7 +72,7 @@ fun <T> Collection<T>.joinToStringWithLimit(context: Context, limit: Int, transf
 
 fun String.isHttpUrl() = startsWith("https://", ignoreCase = true) || startsWith("http://", ignoreCase = true)
 
-fun String.isAnimatedImage() = endsWith(".gif", ignoreCase = true) || endsWith(".webp", ignoreCase = true)
+fun String.isAnimatedImage() = substringBefore("?").run { endsWith(".gif", ignoreCase = true) || endsWith(".webp", ignoreCase = true) }
 
 fun concatStrings(context: Context, a: String?, b: String?): String? = when {
 	a.isNullOrEmpty() && b.isNullOrEmpty() -> null


### PR DESCRIPTION
The `isAnimatedUrl` function was previously using `endsWith` to check for animated image extensions. This failed for URLs that contained query parameters. The function has been updated to use `substringBefore("?")` to remove any query parameters before checking the extension, ensuring that animated images are correctly identified.